### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/docs/2024/agent-code.md
+++ b/docs/2024/agent-code.md
@@ -4,10 +4,10 @@ simulation  Agents
     - https://github.com/microsoft/autogen
 
 - Setup
-    - python3 -m venv pyautogenvenv
-        - Linux -  source pyautogenvenv/bin/activate
-        - Windows - .\pyautogenvenv\Scripts\activate
-    - pip install pyautogen
+    - python3 -m venv ag2venv
+        - Linux -  source ag2venv/bin/activate
+        - Windows - .\ag2venv\Scripts\activate
+    - pip install ag2
     - Docker setup - In a different directory
         - git clone --depth=1 https://github.com/microsoft/autogen
         - docker build -f .devcontainer/Dockerfile -t autogen_base_img https://github.com/microsoft/autogen.git#main


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
